### PR TITLE
Update Docs - fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Calling addBefore will not start the raf.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | fn | <code>function</code> |  | Function to be called at the start of the raf |
-| [prepend] | <code>function</code> | <code>false</code> | Prepend the function to the beginning of the functions list |
+| [prepend] | <code>boolean</code> | <code>false</code> | Prepend the function to the beginning of the functions list |
 
 
 * * *
@@ -106,7 +106,7 @@ Calling addAfter will not start the raf.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | fn | <code>function</code> |  | Function to be called at the end of the raf |
-| [prepend] | <code>function</code> | <code>false</code> | Prepend the function to the beginning of the functions list |
+| [prepend] | <code>boolean</code> | <code>false</code> | Prepend the function to the beginning of the functions list |
 
 
 * * *
@@ -122,7 +122,7 @@ Add a function for execution on each frame
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | fn | <code>function</code> |  | Function to be called |
-| [prepend] | <code>function</code> | <code>false</code> | Prepend the function to the beginning of the functions list |
+| [prepend] | <code>boolean</code> | <code>false</code> | Prepend the function to the beginning of the functions list |
 
 
 * * *
@@ -155,7 +155,6 @@ Calling removeAfter will not stop the raf.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | fn | <code>function</code> |  | Function to remove from the raf |
-| [prepend] | <code>function</code> | <code>false</code> | Prepend the function to the beginning of the functions list |
 
 
 * * *

--- a/lib/raf.js
+++ b/lib/raf.js
@@ -84,7 +84,7 @@ function _removeObserver (arr, fn) {
  * Add a function for execution at the beginning of the raf call
  * Calling addBefore will not start the raf.
  * @param {function} fn Function to be called at the start of the raf
- * @param {function} [prepend=false] Prepend the function to the beginning of the functions list
+ * @param {boolean} [prepend=false] Prepend the function to the beginning of the functions list
  * @static
  * @category methods
  */
@@ -96,7 +96,7 @@ function addBefore (fn, prepend) {
  * Add a function for execution at the end of the raf call
  * Calling addAfter will not start the raf.
  * @param {function} fn Function to be called at the end of the raf
- * @param {function} [prepend=false] Prepend the function to the beginning of the functions list
+ * @param {boolean} [prepend=false] Prepend the function to the beginning of the functions list
  * @static
  * @category methods
  */
@@ -107,7 +107,7 @@ function addAfter (fn, prepend) {
 /**
  * Add a function for execution on each frame
  * @param {function} fn Function to be called
- * @param {function} [prepend=false] Prepend the function to the beginning of the functions list
+ * @param {boolean} [prepend=false] Prepend the function to the beginning of the functions list
  * @static
  * @category methods
  */
@@ -130,11 +130,10 @@ function removeBefore (fn) {
  * Remove a function for execution at the end of the raf call
  * Calling removeAfter will not stop the raf.
  * @param {function} fn Function to remove from the raf
- * @param {function} [prepend=false] Prepend the function to the beginning of the functions list
  * @static
  * @category methods
  */
-function removeAfter (fn, prepend) {
+function removeAfter (fn) {
   _removeObserver(_afterObservers, fn) && _swapRunner()
 }
 


### PR DESCRIPTION
Fix JSDoc comments to specify correct type
Fix method signature and JSDoc comment for removeAfter